### PR TITLE
Use iframe for Chromium perf tests to remove --disable-web-security

### DIFF
--- a/example/fetch_performance_test_iframe.html
+++ b/example/fetch_performance_test_iframe.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<head>
+<script src="util.js"></script>
+<script src="performance_test_iframe.js"></script>
+<script src="fetch_benchmark.js"></script>
+</head>

--- a/example/performance_test_iframe.html
+++ b/example/performance_test_iframe.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<head>
+<script src="util.js"></script>
+<script src="performance_test_iframe.js"></script>
+<script src="benchmark.js"></script>
+</head>

--- a/example/performance_test_iframe.js
+++ b/example/performance_test_iframe.js
@@ -1,0 +1,66 @@
+function perfTestAddToLog(text) {
+  parent.postMessage({'command': 'log', 'value': text}, '*');
+}
+
+function perfTestAddToSummary(text) {
+}
+
+function perfTestMeasureValue(value) {
+  parent.postMessage({'command': 'measureValue', 'value': value}, '*');
+}
+
+function perfTestNotifyAbort() {
+  parent.postMessage({'command': 'notifyAbort'}, '*');
+}
+
+function getConfigForPerformanceTest(connectionType, dataType, async,
+                                     verifyData, numIterations,
+                                     numWarmUpIterations) {
+  var prefixUrl;
+  if (connectionType === 'WebSocket') {
+    prefixUrl = 'ws://' + location.host + '/benchmark_helper';
+  } else {
+    // XHR or fetch
+    prefixUrl = 'http://' + location.host + '/073be001e10950692ccbf3a2ad21c245';
+  }
+
+  return {
+    prefixUrl: prefixUrl,
+    printSize: true,
+    numXHRs: 1,
+    numFetches: 1,
+    numSockets: 1,
+    // + 1 is for a warmup iteration by the Telemetry framework.
+    numIterations: numIterations + numWarmUpIterations + 1,
+    numWarmUpIterations: numWarmUpIterations,
+    minTotal: 10240000,
+    startSize: 10240000,
+    stopThreshold: 10240000,
+    multipliers: [2],
+    verifyData: verifyData,
+    dataType: dataType,
+    async: async,
+    addToLog: perfTestAddToLog,
+    addToSummary: perfTestAddToSummary,
+    measureValue: perfTestMeasureValue,
+    notifyAbort: perfTestNotifyAbort
+  };
+}
+
+var data;
+onmessage = function(message) {
+  var action;
+  if (message.data.command === 'start') {
+    data = message.data;
+    initWorker(data.connectionType, 'http://' + location.host);
+    action = data.benchmarkName;
+  } else {
+    action = 'stop';
+  }
+
+  var config = getConfigForPerformanceTest(data.connectionType, data.dataType,
+                                           data.async, data.verifyData,
+                                           data.numIterations,
+                                           data.numWarmUpIterations);
+  doAction(config, data.isWorker, action);
+};

--- a/example/xhr_performance_test_iframe.html
+++ b/example/xhr_performance_test_iframe.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<head>
+<script src="util.js"></script>
+<script src="performance_test_iframe.js"></script>
+<script src="xhr_benchmark.js"></script>
+</head>


### PR DESCRIPTION
Previously:
(a) util_performance_test.js in Blink runs performance tests using
(b) pywebsocket's scripts,
but this required --disable-web-security for cross-origin workers
because (a) and (b) have different origins.

We change this so that:
(a) util_performance_test.js creates
(c) `<iframe>` with src=pywebsocket's example/*_iframe.html that runs
    the performance tests on the iframe using
(b) pywebsocket's scripts.
Because (b) and (c) have the same origin (but (a) has a different origin),
Tests are run in the same-origin while we have an cross-origin iframe.

This CL adds pywebsocket-side iframe HTML/JavaScript files for (b) and (c).

[1] pywebsocket-side: This CL.
[2] Chromium-side: https://codereview.chromium.org/1521943002/

BUG=https://code.google.com/p/chromium/issues/detail?id=567533