### PR TITLE
Note that you should use pywebsocket3 instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 
 # pywebsocket #
 
-The pywebsocket project aims to provide a [WebSocket](https://tools.ietf.org/html/rfc6455) standalone server and a WebSocket extension for [Apache HTTP Server](https://httpd.apache.org/), mod\_pywebsocket.
+The pywebsocket project aims to provide a
+[WebSocket](https://tools.ietf.org/html/rfc6455) standalone server and a
+WebSocket extension for [Apache HTTP Server](https://httpd.apache.org/),
+mod\_pywebsocket.
+
+This version is no longer maintained. It has been superceded by
+[pywebsocket3](https://github.com/GoogleChromeLabs/pywebsocket3) which works
+with Python 3 in additional to Python 2.
+
+Most existing users should migrate to pywebsocket3.
+
+Support for running as an Apache module has been dropped in pywebsocket3. If you
+need an Apache WebSocket module, you should look for an alternate solution.
 
 pywebsocket is intended for **testing** or **experimental** purposes.
-
-Please see [Wiki](../../wiki) for more details.


### PR DESCRIPTION
Update the README.md file to mention that pywebsocket is unmaintained
and that you should migrate to pywebsocket3 or some other WebSocket
server.